### PR TITLE
Workaround bug for nested DrawerNavigator

### DIFF
--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -343,7 +343,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
     const translateX = Animated.multiply(this.state.scrollAmount, -1);
 
     return (
-      <Animated.View style={[styles.tabBar, this.props.style]}>
+      <Animated.View style={[styles.tabBar, this.props.style, this.props.layout.measured ? {} : { marginBottom: 1 }]}>
         <Animated.View
           pointerEvents="none"
           style={[
@@ -435,7 +435,9 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                 scrollEnabled === true;
               const tabContainerStyle = {};
 
-              tabStyle.width = tabWidth;
+              if (isWidthSet) {
+                tabStyle.width = tabWidth;
+              }
 
               if (passedTabStyle && typeof passedTabStyle.flex === 'number') {
                 tabContainerStyle.flex = passedTabStyle.flex;

--- a/src/TabBar.js
+++ b/src/TabBar.js
@@ -435,9 +435,7 @@ export default class TabBar<T: *> extends React.Component<Props<T>, State> {
                 scrollEnabled === true;
               const tabContainerStyle = {};
 
-              if (isWidthSet) {
-                tabStyle.width = tabWidth;
-              }
+              tabStyle.width = tabWidth;
 
               if (passedTabStyle && typeof passedTabStyle.flex === 'number') {
                 tabContainerStyle.flex = passedTabStyle.flex;


### PR DESCRIPTION
A nested DrawNavigator inside TabNavigator doesn't work. This commit is just workaround for this problem. This bug is discussing here https://github.com/react-navigation/react-navigation/issues/1849