### PR TITLE
fix: checking for event

### DIFF
--- a/src/TabViewPagerAndroid.js
+++ b/src/TabViewPagerAndroid.js
@@ -86,7 +86,10 @@ export default class TabViewPagerAndroid<T: *> extends React.Component<
   };
 
   _handlePageScrollStateChanged = (e: PageScrollState) => {
-    this._isIdle = e === 'idle';
+    this._isIdle =
+      typeof e !== 'string' && e.nativeEvent
+        ? e.nativeEvent.pageScrollState === 'idle'
+        : e === 'idle';
 
     let nextIndex = this._currentIndex;
 


### PR DESCRIPTION
related to [#5713](https://github.com/react-navigation/react-navigation/issues/5713), as fixed in original repo [#724](https://github.com/react-native-community/react-native-tab-view/pull/724)